### PR TITLE
Remove the unused local variable 'test_hash' from TestQuotePresenter

### DIFF
--- a/test/quote_presenter_test.rb
+++ b/test/quote_presenter_test.rb
@@ -15,7 +15,6 @@ class TestQuotePresenter < Minitest::Test
   end
 
   def test_presenter_present
-    test_hash = { 'author' => 'Rainbow Dash', 'quote' => '[So] Awesome!' }
     presenter = QuotePresenter.new(quote_hash: @test_hash)
     assert_equal(@output, presenter.present)
   end


### PR DESCRIPTION
I think that this unused variable must be removed, because it is already defined in the setup method of the test and may confuse the readers of the post.